### PR TITLE
fix(auth): use correct struct for unmarshalling error response body

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -17,10 +17,6 @@ import (
 	"github.com/google/go-querystring/query"
 )
 
-type authError struct {
-	Message string `json:"message"`
-}
-
 type Auth struct {
 	client *Client
 }
@@ -76,10 +72,6 @@ type AuthenticatedDetails struct {
 type authenticationError struct {
 	Error            string `json:"error"`
 	ErrorDescription string `json:"error_description"`
-}
-
-type exchangeError struct {
-	Message string `json:"msg"`
 }
 
 // SignIn enters the user credentials and returns the current user if succeeded.
@@ -143,7 +135,7 @@ func (a *Auth) ExchangeCode(ctx context.Context, opts ExchangeCodeOpts) (*Authen
 
 	req.Header.Set("Content-Type", "application/json")
 	res := AuthenticatedDetails{}
-	errRes := exchangeError{}
+	errRes := ErrorResponse{}
 	hasCustomError, err := a.client.sendCustomRequest(req, &res, &errRes)
 	if err != nil {
 		return nil, err
@@ -163,7 +155,7 @@ func (a *Auth) SendMagicLink(ctx context.Context, email string) error {
 		return err
 	}
 
-	errRes := authError{}
+	errRes := ErrorResponse{}
 	hasCustomError, err := a.client.sendCustomRequest(req, nil, &errRes)
 	if err != nil {
 		return err
@@ -240,7 +232,7 @@ func (a *Auth) User(ctx context.Context, userToken string) (*User, error) {
 
 	injectAuthorizationHeader(req, userToken)
 	res := User{}
-	errRes := authError{}
+	errRes := ErrorResponse{}
 	hasCustomError, err := a.client.sendCustomRequest(req, &res, &errRes)
 	if err != nil {
 		return nil, err
@@ -264,7 +256,7 @@ func (a *Auth) UpdateUser(ctx context.Context, userToken string, updateData map[
 	injectAuthorizationHeader(req, userToken)
 
 	res := User{}
-	errRes := authError{}
+	errRes := ErrorResponse{}
 	hasCustomError, err := a.client.sendCustomRequest(req, &res, &errRes)
 	if err != nil {
 		return nil, err

--- a/supabase.go
+++ b/supabase.go
@@ -29,8 +29,9 @@ type Client struct {
 }
 
 type ErrorResponse struct {
-	Code    int    `json:"code"`
-	Message string `json:"msg"`
+	Code      int    `json:"code"`
+	ErrorCode string `json:"error_code"`
+	Message   string `json:"msg"`
 }
 
 func (err *ErrorResponse) Error() string {


### PR DESCRIPTION
This PR addresses the issue where the majority of Supabase Auth endpoints (`auth/v1`) return error responses that are not properly unmarshaled, making it difficult to handle errors correctly.

Endpoints return error response in following format:
```
{
    "code": 403,
    "error_code": "bad_jwt",
    "msg": "invalid JWT: unable to parse or verify signature, signature is invalid"
}
```

**Fix:**
The error response is now correctly unmarshaled into the appropriate struct, enabling proper handling of errors based on the response fields.

---
Note: Out of scope of this PR, error handling could be improved for the `auth/v1/token?grant_type=refresh_token` and `auth/v1/token?grant_type=password endpoints`, as these endpoints return different bodies in case of errors.