### PR TITLE
feat(storage): add functions for generating signed URLs for upload and download

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -444,8 +444,8 @@ func (f *file) GetPublicUrl(filePath string) SignedURLForDownloadResponse {
 	return response
 }
 
-// Remove deletes a file object
-func (f *file) Remove(filePaths []string) FileResponse {
+// BulkRemove deletes multiple files from a storage bucket
+func (f *file) BulkRemove(filePaths []string) FileResponse {
 	_json, _ := json.Marshal(map[string]interface{}{
 		"prefixes": filePaths,
 	})

--- a/storage.go
+++ b/storage.go
@@ -376,7 +376,7 @@ func (f *file) CreateSignedURLForUpload(filePath string, expiresIn int) (*Signed
 		"expiresIn": expiresIn,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request body: %w", err)
+		return nil, fmt.Errorf("marshaling request body: %w", err)
 	}
 
 	// Route for generating signed url for upload: /object/upload/sign/:bucketId/:objectKey
@@ -384,7 +384,7 @@ func (f *file) CreateSignedURLForUpload(filePath string, expiresIn int) (*Signed
 	reqURL := fmt.Sprintf("%s/%s/object/upload/sign/%s/%s", f.storage.client.BaseURL, StorageEndpoint, f.BucketId, filePath)
 	req, err := http.NewRequest(http.MethodPost, reqURL, bytes.NewBuffer(reqBody))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create http request: %w", err)
+		return nil, fmt.Errorf("creating http request: %w", err)
 	}
 
 	injectAuthorizationHeader(req, f.storage.client.apiKey)
@@ -394,7 +394,7 @@ func (f *file) CreateSignedURLForUpload(filePath string, expiresIn int) (*Signed
 	var errResp FileErrorResponse
 	hasCustomError, err := f.storage.client.sendCustomRequest(req, &resp, &errResp)
 	if err != nil {
-		return nil, fmt.Errorf("failed to send http request: %w", err)
+		return nil, fmt.Errorf("sending http request: %w", err)
 	}
 	if hasCustomError {
 		return nil, &errResp
@@ -409,7 +409,7 @@ func (f *file) CreateSignedURLForDownload(filePath string, expiresIn int) (*Sign
 		"expiresIn": expiresIn,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request body: %w", err)
+		return nil, fmt.Errorf("marshaling request body: %w", err)
 	}
 
 	// Route for generating signed url for download: /object/sign/:bucketId/:objectKey
@@ -417,7 +417,7 @@ func (f *file) CreateSignedURLForDownload(filePath string, expiresIn int) (*Sign
 	reqURL := fmt.Sprintf("%s/%s/object/sign/%s/%s", f.storage.client.BaseURL, StorageEndpoint, f.BucketId, filePath)
 	req, err := http.NewRequest(http.MethodPost, reqURL, bytes.NewBuffer(reqBody))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create http request: %w", err)
+		return nil, fmt.Errorf("creating http request: %w", err)
 	}
 
 	injectAuthorizationHeader(req, f.storage.client.apiKey)
@@ -427,7 +427,7 @@ func (f *file) CreateSignedURLForDownload(filePath string, expiresIn int) (*Sign
 	var errResp FileErrorResponse
 	hasCustomError, err := f.storage.client.sendCustomRequest(req, &resp, &errResp)
 	if err != nil {
-		return nil, fmt.Errorf("failed to send http request: %w", err)
+		return nil, fmt.Errorf("sending http request: %w", err)
 	}
 	if hasCustomError {
 		return nil, &errResp
@@ -451,7 +451,7 @@ func (f *file) Remove(filePath string) error {
 	reqURL := fmt.Sprintf("%s/%s/object/%s/%s", f.storage.client.BaseURL, StorageEndpoint, f.BucketId, filePath)
 	req, err := http.NewRequest(http.MethodDelete, reqURL, nil)
 	if err != nil {
-		return fmt.Errorf("failed to create http request: %w", err)
+		return fmt.Errorf("creating http request: %w", err)
 	}
 
 	injectAuthorizationHeader(req, f.storage.client.apiKey)
@@ -459,7 +459,7 @@ func (f *file) Remove(filePath string) error {
 	var errResp FileErrorResponse
 	hasCustomError, err := f.storage.client.sendCustomRequest(req, nil, &errResp)
 	if err != nil {
-		return fmt.Errorf("failed to send http request: %w", err)
+		return fmt.Errorf("sending http request: %w", err)
 	}
 	if hasCustomError {
 		return &errResp

--- a/storage.go
+++ b/storage.go
@@ -402,7 +402,8 @@ func (f *file) CreateSignedURLForUpload(filePath string, expiresIn int) (*Signed
 		return nil, &errResp
 	}
 
-	resp.SignedURL = f.storage.client.BaseURL + resp.SignedURL
+	// removeEmptyFolder function is used to prevent double slashes in the URL
+	resp.SignedURL = removeEmptyFolder(fmt.Sprintf("%s/%s/%s", f.storage.client.BaseURL, StorageEndpoint, resp.SignedURL))
 	return &resp, nil
 }
 
@@ -435,7 +436,8 @@ func (f *file) CreateSignedURLForDownload(filePath string, expiresIn int) (*Sign
 		return nil, &errResp
 	}
 
-	resp.SignedURL = f.storage.client.BaseURL + resp.SignedURL
+	// removeEmptyFolder function is used to prevent double slashes in the URL
+	resp.SignedURL = removeEmptyFolder(fmt.Sprintf("%s/%s/%s", f.storage.client.BaseURL, StorageEndpoint, resp.SignedURL))
 	return &resp, nil
 }
 

--- a/storage.go
+++ b/storage.go
@@ -199,6 +199,8 @@ type FileResponse struct {
 	Message string `json:"message"`
 }
 
+// FileErrorResponse TODO StatusCode should be int
+// Write custom unmarshaler for statusCode (API returns statusCode field as string)
 type FileErrorResponse struct {
 	StatusCode string `json:"statusCode"`
 	ShortError string `json:"error"`

--- a/storage.go
+++ b/storage.go
@@ -437,8 +437,8 @@ func (f *file) CreateSignedURLForDownload(filePath string, expiresIn int) (*Sign
 	return &resp, nil
 }
 
-// GetPublicUrl get a public signed url of a file object
-func (f *file) GetPublicUrl(filePath string) SignedURLForDownloadResponse {
+// GetPublicURL get a public signed url of a file object
+func (f *file) GetPublicURL(filePath string) SignedURLForDownloadResponse {
 	var response SignedURLForDownloadResponse
 	response.SignedURL = fmt.Sprintf("%s/%s/object/public/%s/%s", f.storage.client.BaseURL, StorageEndpoint, f.BucketId, filePath)
 	return response


### PR DESCRIPTION
- Adds function to generate signed URLs for uploading storage objects
- Fixes issues with generating signed URLs for downloading objects
- Functions for generating signed urls return errors instead of panicking on failure
- Adds function for deleting a single object from storage

**IMPORTANT**
This PR introduces breaking changes

- Function signature for generating signed url for download has been changed:
```diff
- func(f *file) CreateSignedUrl(filePath string, expiresIn int) SignedUrlResponse
+ func(f *file) CreateSignedURLForDownload(filePath string, expiresIn int) (*SignedURLForDownloadResponse, error)
```

- Function signature for bulk files remove has bee changed 
```diff
- func(f *file) Remove(filePaths []string) FileResponse
+ func(f *file) BulkRemove(filePaths []string) FileResponse
```
`BulkRemove` function could also benefit from refactoring, but it is not the goal of this PR.

- Function signature for generating file URL in public bucket:

```diff
- func (f *file) GetPublicUrl(filePath string) SignedUrlResponse
+ func (f *file) GetPublicURL(filePath string) SignedURLForDownloadResponse
```

**Note:** 
The Supabase client could benefit from further refactoring, but this PR focuses on fixing issues and adding functionality for generating signed URLs (and deleting single object from storage) in the current implementation. The current changes could be optimized but achieving that would require further refactoring.